### PR TITLE
Add support for parsing globals in WAT

### DIFF
--- a/src/module.zig
+++ b/src/module.zig
@@ -179,7 +179,7 @@ pub const Instr = struct {
     arg: Op.Arg,
 };
 
-const InitExpr = union(enum) {
+pub const InitExpr = union(enum) {
     i32_const: i32,
     i64_const: i64,
     f32_const: f32,

--- a/src/wat.zig
+++ b/src/wat.zig
@@ -551,12 +551,12 @@ pub fn parseNoValidate(allocator: *std.mem.Allocator, reader: anytype) !Module {
                 var id_buf: [0x10]u8 = undefined;
                 const id = (try command.next(&id_buf)) orelse return error.ExpectedNext;
 
+                var next_buf: [0x20]u8 = undefined;
                 const next = blk: {
                     // a comment was skipped so 'id' is the actual Atom/List we want
                     if (id != .Atom or id.Atom[0] != '$') break :blk id;
 
                     // if it was an id get next list/atom
-                    var next_buf: [0x20]u8 = undefined;
                     break :blk (try command.next(&next_buf)) orelse return error.ExpectedNext;
                 };
 


### PR DESCRIPTION
Besides parsing globals I had to make a couple of changes to get this to work:

1. Had to make `InitExpr` public so that the switch allowed to initialize a new `InitExpr`.
2. Had to make the `Next` union a tagged one. This was needed so I could detect if the 'next' item was a List (in case of a mutable global) or simply an Atom (immutable global).
3. `List.next()` seemed to check incorrectly if we were at the end or not, causing it to always return `null`

The only use case that does not yet work is mutable globals that can be exported like so:
```wast
(module (global (export "a") (mut f32) (f32.const 0)))
```