### PR TITLE
Implement globals

### DIFF
--- a/src/execution.zig
+++ b/src/execution.zig
@@ -11,6 +11,7 @@ memory: *Memory,
 funcs: []const Instance.Func,
 allocator: *std.mem.Allocator,
 jumps: Module.InstrJumps,
+globals: []Op.Fixval,
 
 stack: []Op.Fixval,
 stack_top: usize,
@@ -22,6 +23,7 @@ pub fn run(instance: *Instance, stack: []Op.Fixval, func_id: usize, params: []Op
         .funcs = instance.funcs,
         .allocator = instance.allocator,
         .jumps = instance.module.jumps,
+        .globals = try instance.allocator.alloc(Op.Fixval, instance.globals.len),
 
         .stack = stack,
         .stack_top = 0,
@@ -30,6 +32,28 @@ pub fn run(instance: *Instance, stack: []Op.Fixval, func_id: usize, params: []Op
     // initCall assumes the params are already pushed onto the stack
     for (params) |param| {
         try ctx.push(Op.Fixval, param);
+    }
+
+    // set globals and afterwards copy globals back into instance
+    for (ctx.globals) |*global, i| {
+        global.* = switch (instance.globals[i]) {
+            .I32 => |val| .{ .I32 = val },
+            .I64 => |val| .{ .I64 = val },
+            .F32 => |val| .{ .F32 = val },
+            .F64 => |val| .{ .F64 = val },
+        };
+    }
+    defer {
+        for (instance.globals) |*global, i| {
+            const cur = ctx.globals[i];
+            global.* = switch (global.*) {
+                .I32 => .{ .I32 = cur.I32 },
+                .I64 => .{ .I64 = cur.I64 },
+                .F32 => .{ .F32 = cur.F32 },
+                .F64 => .{ .F64 = cur.F64 },
+            };
+        }
+        ctx.allocator.free(ctx.globals);
     }
 
     try ctx.initCall(func_id);
@@ -94,11 +118,11 @@ fn localOffset(self: Execution) usize {
 }
 
 pub fn getGlobal(self: Execution, idx: usize) Op.Fixval {
-    @panic("TODO");
+    return self.globals[idx];
 }
 
 pub fn setGlobal(self: Execution, idx: usize, value: anytype) void {
-    @panic("TODO");
+    self.globals[idx] = value;
 }
 
 pub fn initCall(self: *Execution, func_id: usize) !void {

--- a/src/func/global.zig
+++ b/src/func/global.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+
+const Wat = @import("../wat.zig");
+const Instance = @import("../instance.zig");
+
+test "get global" {
+    var fbs = std.io.fixedBufferStream(
+        \\(module
+        \\  (global (;0;) i32 (i32.const 10))
+        \\  (func (param i32) (result i32)
+        \\    local.get 0
+        \\	  global.get 0
+        \\    i32.add)
+        \\  (export "add" (func 0)))
+    );
+    var module = try Wat.parse(std.testing.allocator, fbs.reader());
+    defer module.deinit();
+
+    var instance = try module.instantiate(std.testing.allocator, null, struct {});
+    defer instance.deinit();
+
+    {
+        const result = try instance.call("add", .{@as(i32, 1)});
+        std.testing.expectEqual(@as(i32, 11), result.?.I32);
+    }
+    {
+        const result = try instance.call("add", .{@as(i32, 5)});
+        std.testing.expectEqual(@as(i32, 15), result.?.I32);
+    }
+}
+
+test "set global" {
+    var fbs = std.io.fixedBufferStream(
+        \\(module
+        \\  (global (;0;) i32 (i32.const 0))
+        \\  (func (param i32)
+        \\    local.get 0
+        \\	  global.set 0)
+        \\  (export "get" (func 0)))
+    );
+    var module = try Wat.parse(std.testing.allocator, fbs.reader());
+    defer module.deinit();
+
+    var instance = try module.instantiate(std.testing.allocator, null, struct {});
+    defer instance.deinit();
+
+    {
+        const result = try instance.call("get", .{@as(i32, 1)});
+        std.testing.expectEqual(Instance.Value{ .I32 = 1 }, instance.globals[0]);
+    }
+
+    {
+        const result = try instance.call("get", .{@as(i32, 5)});
+        std.testing.expectEqual(Instance.Value{ .I32 = 5 }, instance.globals[0]);
+    }
+}

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -92,6 +92,7 @@ pub fn init(module: *const Module, allocator: *std.mem.Allocator, context: ?*c_v
 
 pub fn deinit(self: *Instance) void {
     self.allocator.free(self.funcs);
+    self.allocator.free(self.globals);
     self.memory.deinit();
     self.exports.deinit();
     self.* = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,4 +32,5 @@ test "" {
     _ = @import("func/basic.zig");
     _ = @import("func/imports.zig");
     _ = @import("func/logic.zig");
+    _ = @import("func/global.zig");
 }

--- a/src/module.zig
+++ b/src/module.zig
@@ -179,7 +179,7 @@ pub const Instr = struct {
     arg: Op.Arg,
 };
 
-const InitExpr = union(enum) {
+pub const InitExpr = union(enum) {
     i32_const: i32,
     i64_const: i64,
     f32_const: f32,


### PR DESCRIPTION
- Adds a check to ensure the indices of locals and globals are the correct type and not out of bounds.
- Wrote tests for both cases.
- Implemented setting and getting of globals. (Does not really check for mutability right now outside parsing)
- Test cases for globals

Globals being of type `Value` where the runtime seems to be using `Fixval` is maybe not so clean. But for now, I moved `Instance` to `Execution` so we at least don't need to copy over globals for each `call()`.
Tried to also replace the other field members but noticed that `src/op.zig` has a lot of references to those and decided it's probably worth a seperate PR. 
